### PR TITLE
To ensure the application's compatibility and functionality, it was necessary to downgrade the setuptools module from version 82+ to <82. The pkg_resources file is no longer included in version 82+.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,13 @@
+# Setuptools: Critical Fix for Recent Environments (Setuptools 82+).
+# As of February 2026, setuptools version 82.0.0 and newer have 
+# officially removed pkg_resources. Or run command if Linux (distro based in Debian)
+# $ sudo apt install --reinstall python3-pkg-resources python3-setuptools
+
+# Setuptools
+setuptools<82
+
 # Core
-django==4.2.8
+django==4.2.81
 python-dotenv==1.0.0
 str2bool==1.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 setuptools<82
 
 # Core
-django==4.2.81
+django==4.2.8
 python-dotenv==1.0.0
 str2bool==1.1
 


### PR DESCRIPTION
Critical Fix for Recent Environments (Setuptools 82+)
As of February 2026, setuptools version 82.0.0 and newer have officially removed pkg_resources. If you are running legacy code that still requires it, you must downgrade to the last compatible version: setuptools<82